### PR TITLE
Suggested fix for #5 (Inheritance)

### DIFF
--- a/src/accessors.d
+++ b/src/accessors.d
@@ -1,4 +1,4 @@
-module accessors_;
+module accessors;
 
 struct Read
 {

--- a/src/accessors.d
+++ b/src/accessors.d
@@ -1,4 +1,4 @@
-module accessors;
+module accessors_;
 
 struct Read
 {
@@ -22,7 +22,7 @@ struct Write
 
 immutable string GenerateFieldAccessors = `
     mixin GenerateFieldAccessorMethods;
-    mixin(GenerateFieldAccessorMethods);
+    mixin(GenerateFieldAccessorMethods2);
     `;
 
 mixin template GenerateFieldAccessorMethods()
@@ -31,7 +31,7 @@ mixin template GenerateFieldAccessorMethods()
 
     private enum bool isNotThis(string T) = T != "this";
 
-    static enum GenerateFieldAccessorMethods()
+    static enum GenerateFieldAccessorMethods2()
     {
         import std.traits : hasUDA;
 
@@ -664,5 +664,25 @@ unittest
         auto y = foo;
 
         static assert(is(typeof(y) == const(X)[]));
+    }
+}
+
+/// Inheritance (https://github.com/funkwerk/accessors/issues/5)
+unittest
+{
+    class A
+    {
+        @Read
+        string foo_;
+
+        mixin(GenerateFieldAccessors);
+    }
+
+    class B : A
+    {
+        @Read
+        string bar_;
+
+        mixin(GenerateFieldAccessors);
     }
 }

--- a/src/accessors.d
+++ b/src/accessors.d
@@ -37,7 +37,7 @@ mixin template GenerateFieldAccessorMethods()
 
         string result = "";
 
-        foreach (name; Filter!(isNotThis, __traits(allMembers, typeof(this))))
+        foreach (name; Filter!(isNotThis, __traits(derivedMembers, typeof(this))))
         {
             alias field = Alias!(__traits(getMember, typeof(this), name));
 

--- a/src/accessors.d
+++ b/src/accessors.d
@@ -22,7 +22,7 @@ struct Write
 
 immutable string GenerateFieldAccessors = `
     mixin GenerateFieldAccessorMethods;
-    mixin(GenerateFieldAccessorMethods2);
+    mixin(GenerateFieldAccessorMethodsImpl);
     `;
 
 mixin template GenerateFieldAccessorMethods()
@@ -31,7 +31,7 @@ mixin template GenerateFieldAccessorMethods()
 
     private enum bool isNotThis(string T) = T != "this";
 
-    static enum GenerateFieldAccessorMethods2()
+    static enum GenerateFieldAccessorMethodsImpl()
     {
         import std.traits : hasUDA;
 


### PR DESCRIPTION
The commit comments should adequately explain the two points that I understand to be necessary to fix issue #5 .

Note that GenerateFieldAccessorMethods2 is surely a poor name which needs replacement, but I don't understand the mixin/template magic well enough to be able to name either of the two candidates more correctly ,-)
