### PR TITLE
auto return type for accessors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .dub
 __test__*__
 /accessors-test-library
+/accessors

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ os:
 language: d
 
 d:
- - dmd-2.073.1
- - dmd-2.072.2
+ - dmd-2.076.1
+ - dmd-2.075.1
+ - dmd-2.074.1
 
 env: 
  matrix:

--- a/dub.json
+++ b/dub.json
@@ -11,6 +11,12 @@
 	"configurations": [
 		{
 			"name": "library"
+		},
+		{
+			"name": "unittest",
+			"targetType": "executable",
+			"sourcePaths": ["test"],
+			"mainSourceFile": "test/main.d"
 		}
 	]
 }

--- a/src/accessors.d
+++ b/src/accessors.d
@@ -92,7 +92,7 @@ template GenerateReader(string name, alias field)
         static if (isArray!(typeof(field)) && !isSomeString!(typeof(field)))
         {
             return format("%s final @property auto %s() inout {"
-                        ~ "import std.traits;"
+                        ~ "import std.traits : ForeachType;"
                         ~ "inout(ForeachType!(typeof(this.%s)))[] result = null;"
                         ~ "return result ~ this.%s;"
                         ~ "}",
@@ -119,7 +119,7 @@ unittest
         "public final @property auto foo() inout { return this.foo; }");
     static assert(GenerateReader!("foo", intArrayValue) ==
         "public final @property auto foo() inout {"
-      ~ "import std.traits;"
+      ~ "import std.traits : ForeachType;"
       ~ "inout(ForeachType!(typeof(this.foo)))[] result = null;"
       ~ "return result ~ this.foo;"
       ~ "}");

--- a/src/accessors.d
+++ b/src/accessors.d
@@ -92,11 +92,9 @@ template GenerateReader(string name, alias field)
         static if (isArray!(typeof(field)) && !isSomeString!(typeof(field)))
         {
             return format("%s final @property auto %s() inout {"
-                        ~ "import std.traits : ForeachType;"
-                        ~ "inout(ForeachType!(typeof(this.%s)))[] result = null;"
-                        ~ "return result ~ this.%s;"
+                        ~ "return [] ~ this.%s;"
                         ~ "}",
-                          visibility, accessorName, name, name);
+                          visibility, accessorName, name);
         }
         else
         {
@@ -119,9 +117,7 @@ unittest
         "public final @property auto foo() inout { return this.foo; }");
     static assert(GenerateReader!("foo", intArrayValue) ==
         "public final @property auto foo() inout {"
-      ~ "import std.traits : ForeachType;"
-      ~ "inout(ForeachType!(typeof(this.foo)))[] result = null;"
-      ~ "return result ~ this.foo;"
+      ~ "return [] ~ this.foo;"
       ~ "}");
 }
 

--- a/src/accessors.d
+++ b/src/accessors.d
@@ -91,7 +91,7 @@ template GenerateReader(string name, alias field)
 
         static if (isArray!(typeof(field)) && !isSomeString!(typeof(field)))
         {
-            return format("%s final @property auto %s() inout {"
+            return format("%s final @property auto %s() {"
                         ~ "return [] ~ this.%s;"
                         ~ "}",
                           visibility, accessorName, name);
@@ -116,7 +116,7 @@ unittest
     static assert(GenerateReader!("foo", stringValue) ==
         "public final @property auto foo() inout { return this.foo; }");
     static assert(GenerateReader!("foo", intArrayValue) ==
-        "public final @property auto foo() inout {"
+        "public final @property auto foo() {"
       ~ "return [] ~ this.foo;"
       ~ "}");
 }
@@ -711,5 +711,26 @@ unittest
         string bar_;
 
         mixin(GenerateFieldAccessors);
+    }
+}
+
+/// @Read property returns array with mutable elements.
+unittest
+{
+    struct Field
+    {
+    }
+
+    struct S
+    {
+        @Read
+        Field[] foo_;
+
+        mixin(GenerateFieldAccessors);
+    }
+
+    with (S())
+    {
+        Field[] arr = foo;
     }
 }

--- a/test/PersonId.d
+++ b/test/PersonId.d
@@ -1,0 +1,5 @@
+module PersonId;
+
+class PersonId
+{
+}

--- a/test/main.d
+++ b/test/main.d
@@ -5,7 +5,7 @@ void main()
 }
 
 // Issue #11: https://github.com/funkwerk/accessors/issues/11
-pure nothrow @safe @nogc unittest
+@nogc nothrow pure @safe unittest
 {
     import PersonId : AnotherPersonId = PersonId;
 

--- a/test/main.d
+++ b/test/main.d
@@ -1,0 +1,26 @@
+import accessors;
+
+void main()
+{
+}
+
+// Issue #11: https://github.com/funkwerk/accessors/issues/11
+pure nothrow @safe @nogc unittest
+{
+    import PersonId : AnotherPersonId = PersonId;
+
+    class PersonId
+    {
+    }
+
+    class Foo
+    {
+        @ConstRead
+        private AnotherPersonId anotherPersonId_;
+
+        @Read
+        private AnotherPersonId[] personIdArray_;
+
+        mixin(GenerateFieldAccessors);
+    }
+}


### PR DESCRIPTION
This is a suggestion to fix #11.

Instead of using a string as the accessor return type, it may be better to use `auto`, so the compiler can infer the return type based on the type of the appropriate class/struct member.

Marking the property as const/inout seems to be enough for the compiler to infer the return type with the correct mutability.