### PR TITLE
Added deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 `accessors` module allows to generate getters and setters automatically.
 
+**Deprecation warning:** `accessors` has been succeeded by [boilerplate](https://github.com/funkwerk/boilerplate).
+
 ## Usage
 
 ```d


### PR DESCRIPTION
we probably shouldn't officially support two libraries doing the same. How to solve this? Could accessors be marked as deprecated?